### PR TITLE
Fix Markdown syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ Then, this rule can be used as one of the `srcs` of another rules, such as a `ja
 
 ## Example
  The example "jflex.examples.helloworld" generates a lexer from `helloworld.flex` with:
+ 
      jflex(
         name = "gen_hello_lexer",
         srcs = ["helloworld.flex"],
         outputs = ["HelloWorld.java"],
     )
+ 
  See `java/jflex/examples/helloworld`.
+ 
  ## Directory layout
  ```
 ├── assets                 → assets for the web site


### PR DESCRIPTION
missing empty line for code block