### PR TITLE
Revert jflex_deps() to use maven_jar

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,11 @@
 # This WORKSPACE file defines the workspace for the Bazel build system.
 # See https://docs.bazel.build/versions/master/build-ref.html#workspace
 
-load("//jflex:deps.bzl", "JFLEX_DEPS")
+load("//jflex:deps.bzl", "jflex_deps")
 load("//third_party:third_party_deps.bzl", "THIRD_PARTY_ARTIFACTS")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+jflex_deps()
 
 RULES_JVM_EXTERNAL_TAG = "2.10"
 
@@ -23,7 +25,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     name = "maven",
-    artifacts = THIRD_PARTY_ARTIFACTS + JFLEX_DEPS,
+    artifacts = THIRD_PARTY_ARTIFACTS,
     repositories = [
         "https://jcenter.bintray.com/",
         "https://maven.google.com/",

--- a/jflex/BUILD
+++ b/jflex/BUILD
@@ -14,12 +14,12 @@ java_binary(
     ],
 )
 
-alias(
+java_library(
     name = "jflex",
-    actual = "@maven//:de_jflex_jflex_1_7_0",
+    exports = ["@de_jflex_jflex_1_7_0//jar"],
 )
 
-alias(
+java_library(
     name = "cup_runtime",
-    actual = "@maven//:de_jflex_cup_runtime_11b",
+    exports = ["@de_jflex_cup_runtime_11b//jar"],
 )

--- a/jflex/deps.bzl
+++ b/jflex/deps.bzl
@@ -1,6 +1,17 @@
-# Copyright 2018-2019 Google LLC.
+# Copyright 2018 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
-JFLEX_DEPS = [
-    "de.jflex:jflex:1.7.0",
-    "de.jflex:cup_runtime:11b",
-]
+
+def jflex_deps():
+    """Bazel macro that iports dependencies used by JFlex."""
+
+    native.maven_jar(
+        name = "de_jflex_jflex_1_7_0",
+        artifact = "de.jflex:jflex:1.7.0",
+        repository = "https://jcenter.bintray.com/",
+    )
+
+    native.maven_jar(
+        name = "de_jflex_cup_runtime_11b",
+        artifact = "de.jflex:cup_runtime:11b",
+        repository = "https://jcenter.bintray.com/",
+    )

--- a/jflex/deps.bzl
+++ b/jflex/deps.bzl
@@ -8,10 +8,14 @@ def jflex_deps():
         name = "de_jflex_jflex_1_7_0",
         artifact = "de.jflex:jflex:1.7.0",
         repository = "https://jcenter.bintray.com/",
+        sha256 = "c40e64600f7d29e1618a1c1d5cd697c926ff8495e166ea9416cae19644e37ae6",
+        sha256_src = "3b18eb44332183ac1fbbf4573da1f2e8a373b71899a9d05a0d70308d5c5a56f3",
     )
 
     native.maven_jar(
         name = "de_jflex_cup_runtime_11b",
         artifact = "de.jflex:cup_runtime:11b",
         repository = "https://jcenter.bintray.com/",
+        sha256 = "9c0b5c93fe0c0e239d5f92affb672cb7c45122c3e3de8cda9513fa8e39dbbc3c",
+        sha256_src = "7155a72ab7b2d6c1ecf129bcacfbe942d0b490bfe1d634532e5619a836e17591",
     )


### PR DESCRIPTION
Partial revert of #14 

The change was hard to use, with a complex setup of WORKSPACE.

Keep the deprecated `native.maven_jar` rule on `jflex_deps()` to ease usage by client projects.

Add the sha256 sums on the maven_jar.
