### PR TITLE
Add data attribute to the jflex rule

### DIFF
--- a/java/jflex/examples/nested_grammar/BUILD
+++ b/java/jflex/examples/nested_grammar/BUILD
@@ -1,0 +1,19 @@
+# Use of the data attribute for nested grammars
+load("//jflex:jflex.bzl", "jflex")
+
+jflex(
+    name = "gen_nested_grammar",
+    srcs = ["nested_grammar.jflex"],
+    data = ["extra-jflex-rules.inc.jflex"],
+    outputs = ["NestedRulesScanner.java"],
+)
+
+java_library(
+    name = "nested_grammar",
+    srcs = [
+        "Token.java",
+        ":gen_nested_grammar",
+    ],
+    visibility = ["//javatests/jflex/examples/nested_grammar:__pkg__"],
+    deps = [],
+)

--- a/java/jflex/examples/nested_grammar/Token.java
+++ b/java/jflex/examples/nested_grammar/Token.java
@@ -1,0 +1,8 @@
+package jflex.examples.nested_grammar;
+
+public enum Token {
+  FOO,
+  BAR,
+  HELLO,
+  EOF,
+}

--- a/java/jflex/examples/nested_grammar/extra-jflex-rules.inc.jflex
+++ b/java/jflex/examples/nested_grammar/extra-jflex-rules.inc.jflex
@@ -1,0 +1,1 @@
+"hello" {return Token.HELLO;}

--- a/java/jflex/examples/nested_grammar/nested_grammar.jflex
+++ b/java/jflex/examples/nested_grammar/nested_grammar.jflex
@@ -1,0 +1,18 @@
+package jflex.examples.nested_grammar;
+
+%%
+
+%unicode
+%public
+%class NestedRulesScanner
+%type Token
+
+%%
+
+"foo" { return Token.FOO; }
+%include extra-jflex-rules.inc.jflex
+"bar" { return Token.BAR; }
+
+[^] { }
+
+<<EOF>> { return Token.EOF; }

--- a/javatests/jflex/examples/nested_grammar/BUILD
+++ b/javatests/jflex/examples/nested_grammar/BUILD
@@ -1,0 +1,9 @@
+java_test(
+    name = "NestedGrammarTest",
+    srcs = ["NestedGrammarTest.java"],
+    deps = [
+        "//java/jflex/examples/nested_grammar",
+        "//third_party/com/google/guava",
+        "//third_party/com/google/truth",
+    ],
+)

--- a/javatests/jflex/examples/nested_grammar/NestedGrammarTest.java
+++ b/javatests/jflex/examples/nested_grammar/NestedGrammarTest.java
@@ -1,0 +1,48 @@
+package jflex.examples.nested_grammar;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.io.CharSource;
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Test;
+
+public class NestedGrammarTest {
+
+  private NestedRulesScanner scanner;
+
+  @After
+  public void eof() throws Exception {
+    assertThat(scanner.yylex()).isEqualTo(Token.EOF);
+  }
+
+  @Test
+  public void foo() throws Exception {
+    scanner = createScanner("foo");
+    assertThat(scanner.yylex()).isEqualTo(Token.FOO);
+  }
+
+  @Test
+  public void bar() throws Exception {
+    scanner = createScanner("bar");
+    assertThat(scanner.yylex()).isEqualTo(Token.BAR);
+  }
+
+  @Test
+  public void hello() throws Exception {
+    scanner = createScanner("hello");
+    assertThat(scanner.yylex()).isEqualTo(Token.HELLO);
+  }
+
+  @Test
+  public void sentence() throws Exception {
+    scanner = createScanner("foo bar hello world");
+    assertThat(scanner.yylex()).isEqualTo(Token.FOO);
+    assertThat(scanner.yylex()).isEqualTo(Token.BAR);
+    assertThat(scanner.yylex()).isEqualTo(Token.HELLO);
+  }
+
+  private NestedRulesScanner createScanner(String content) throws IOException {
+    return new NestedRulesScanner(CharSource.wrap(content).openStream());
+  }
+}

--- a/jflex/jflex.bzl
+++ b/jflex/jflex.bzl
@@ -31,7 +31,7 @@ def _jflex_impl(ctx):
     )
     ctx.actions.run(
         mnemonic = "jflex",
-        inputs = ctx.files.srcs + maybe_skel,
+        inputs = ctx.files.srcs + ctx.files.data + maybe_skel,
         outputs = ctx.outputs.outputs,
         executable = ctx.executable.jflex_bin,
         arguments = arguments,
@@ -46,6 +46,10 @@ jflex = rule(
             allow_files = True,
             mandatory = True,
             doc = "a list of grammar specifications",
+        ),
+        "data": attr.label_list(
+            allow_files = True,
+            doc = "extra files to pass to the rule, e.g. included grammar specs",
         ),
         "jlex": attr.bool(
             doc = "JLex compatibility increaed. In particular, this changes how caseless behaves.",


### PR DESCRIPTION
The `data` attr allows to pass files included in the spec. The `src` only accepts scanner specifications,
