### PR TITLE
Replace maven_jar by maven_install from rules_jvm_external

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ and add `JFLEX_ARTIFACTS` in your `maven_install` rule:
         ],
     )
 
+If this is the first time you use `maven_install`, you need to generate the `maven_install.json` with
+ 
+```
+bazel run @maven//:pin
+```
+
+If you already used `mven_install` before, you need to update the pinned artifacts with:
+
+```
+bazel run @unpinned_maven//:pin
+```
+
 ## Usage in BUILD files
 
     load("@jflex_rules//jflex:jflex.bzl", "jflex")

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ This is not an officially supported Google product.
 
 ## Prepare your Bazel workspace
 
-Load the **bazel_rules** in your [`WORKSPACE` file][be_workspace]:
+### Add a dependency on rules_jvm_external
+
+See [bazelbuild/rules_jvm_external][bb_jvm_external].
+
+### Load the jflex rule
+
+Load the **bazel_rules** in your [`WORKSPACE` file][be_workspace]
+and add `JFLEX_ARTIFACTS` in your `maven_install` rule:
 
     load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
@@ -30,11 +37,18 @@ Load the **bazel_rules** in your [`WORKSPACE` file][be_workspace]:
             branch = "stable",
     )
 
-    load("@jflex_rules//jflex:deps.bzl", "jflex_deps")
+    load("@jflex_rules//jflex:deps.bzl", "JFLEX_ARTIFACTS")
 
-    # If you want to use JFlex.
-    jflex_deps()
-
+    maven_install(
+        name = "maven",
+        artifacts = JFLEX_ARTIFACTS,
+        maven_install_json = "//:maven_install.json",
+        repositories = [
+            "https://jcenter.bintray.com/",
+            "https://maven.google.com",
+            "https://repo1.maven.org/maven2",
+        ],
+    )
 
 ## Usage in BUILD files
 
@@ -77,3 +91,4 @@ For more details, see [cup](cup) and [jflex](jflex).
 [cup]: http://www2.cs.tum.edu/projects/cup/
 [be_maven_jar]: https://docs.bazel.build/versions/master/be/workspace.html#maven_jar
 [be_workspace]: https://docs.bazel.build/versions/master/tutorial/java.html#set-up-the-workspace 
+[bb_jvm_external]: https://github.com/bazelbuild/rules_jvm_external

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,9 @@
 # This WORKSPACE file defines the workspace for the Bazel build system.
 # See https://docs.bazel.build/versions/master/build-ref.html#workspace
 
-load("//jflex:deps.bzl", "jflex_deps")
+load("//jflex:deps.bzl", "JFLEX_ARTIFACTS")
 load("//third_party:third_party_deps.bzl", "THIRD_PARTY_ARTIFACTS")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-jflex_deps()
 
 RULES_JVM_EXTERNAL_TAG = "2.10"
 
@@ -25,7 +23,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     name = "maven",
-    artifacts = THIRD_PARTY_ARTIFACTS,
+    artifacts = JFLEX_ARTIFACTS + THIRD_PARTY_ARTIFACTS,
     maven_install_json = "//:maven_install.json",
     repositories = [
         "https://jcenter.bintray.com/",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,9 +8,10 @@ load("//jflex:deps.bzl", "JFLEX_ARTIFACTS")
 load("//third_party:third_party_deps.bzl", "THIRD_PARTY_ARTIFACTS")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-RULES_JVM_EXTERNAL_TAG = "2.10"
+RULES_JVM_EXTERNAL_TAG = "3.2"
 
-RULES_JVM_EXTERNAL_SHA = "1bbf2e48d07686707dd85357e9a94da775e1dbd7c464272b3664283c9c716d26"
+RULES_JVM_EXTERNAL_SHA = "82262ff4223c5fda6fb7ff8bd63db8131b51b413d26eb49e3131037e79e324af"
+
 
 http_archive(
     name = "rules_jvm_external",

--- a/jflex/BUILD
+++ b/jflex/BUILD
@@ -16,10 +16,10 @@ java_binary(
 
 java_library(
     name = "jflex",
-    exports = ["@de_jflex_jflex_1_7_0//jar"],
+    exports = ["@maven//:de_jflex_jflex"],
 )
 
 java_library(
     name = "cup_runtime",
-    exports = ["@de_jflex_cup_runtime_11b//jar"],
+    exports = ["@maven//:de_jflex_cup_runtime"],
 )

--- a/jflex/deps.bzl
+++ b/jflex/deps.bzl
@@ -1,21 +1,7 @@
 # Copyright 2018 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-def jflex_deps():
-    """Bazel macro that iports dependencies used by JFlex."""
-
-    native.maven_jar(
-        name = "de_jflex_jflex_1_7_0",
-        artifact = "de.jflex:jflex:1.7.0",
-        repository = "https://jcenter.bintray.com/",
-        sha256 = "c40e64600f7d29e1618a1c1d5cd697c926ff8495e166ea9416cae19644e37ae6",
-        sha256_src = "3b18eb44332183ac1fbbf4573da1f2e8a373b71899a9d05a0d70308d5c5a56f3",
-    )
-
-    native.maven_jar(
-        name = "de_jflex_cup_runtime_11b",
-        artifact = "de.jflex:cup_runtime:11b",
-        repository = "https://jcenter.bintray.com/",
-        sha256 = "9c0b5c93fe0c0e239d5f92affb672cb7c45122c3e3de8cda9513fa8e39dbbc3c",
-        sha256_src = "7155a72ab7b2d6c1ecf129bcacfbe942d0b490bfe1d634532e5619a836e17591",
-    )
+JFLEX_ARTIFACTS=[
+    "de.jflex:jflex:1.7.0",
+    "de.jflex:cup_runtime:11b",
+]


### PR DESCRIPTION
The native `maven_jar` rule has been deprecated in bazel 1.2.0 https://docs.bazel.build/versions/1.2.0/be/workspace.html#maven_jar and removed in bazel 2.0.0

