### PR TITLE
update README.md for JFlex 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ and add `JFLEX_ARTIFACTS` in your `maven_install` rule:
     http_archive(
         name = "jflex_rules",
         sha256 = "a4a9d59f39d4055c2deddd8058cf28baee916116a743d200c4bba58a13b9e184",
-        strip_prefix = "bazel_rules-1.8.2",
-        url = "https://github.com/jflex-de/bazel_rules/archive/v1.8.2.tar.gz",
+        strip_prefix = "bazel_rules-1.9.0",
+        url = "https://github.com/jflex-de/bazel_rules/archive/v1.9.0.tar.gz",
     )
 
     load("@jflex_rules//jflex:deps.bzl", "JFLEX_ARTIFACTS")


### PR DESCRIPTION
sha256 value can only be updated after the release is tagged
